### PR TITLE
Update all official CKEditor dependencies to version 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ckeditor5-math",
-  "version": "19.0.0",
+  "version": "20.0.0",
   "description": "Math feature for CKEditor 5.",
   "keywords": [
     "ckeditor",
@@ -10,19 +10,19 @@
     "ckeditor5-plugin"
   ],
   "dependencies": {
-    "@ckeditor/ckeditor5-clipboard": "^19.0.0",
-    "@ckeditor/ckeditor5-core": "^19.0.0",
-    "@ckeditor/ckeditor5-engine": "^19.0.0",
-    "@ckeditor/ckeditor5-ui": "^19.0.0",
-    "@ckeditor/ckeditor5-undo": "^19.0.0",
-    "@ckeditor/ckeditor5-utils": "^19.0.0",
-    "@ckeditor/ckeditor5-widget": "^19.0.0"
+    "@ckeditor/ckeditor5-clipboard": "^20.0.0",
+    "@ckeditor/ckeditor5-core": "^20.0.0",
+    "@ckeditor/ckeditor5-engine": "^20.0.0",
+    "@ckeditor/ckeditor5-ui": "^20.0.0",
+    "@ckeditor/ckeditor5-undo": "^20.0.0",
+    "@ckeditor/ckeditor5-utils": "^20.0.0",
+    "@ckeditor/ckeditor5-widget": "^20.0.0"
   },
   "devDependencies": {
-    "@ckeditor/ckeditor5-dev-tests": "^19.0.0",
-    "@ckeditor/ckeditor5-editor-inline": "^19.0.0",
-    "@ckeditor/ckeditor5-essentials": "^19.0.0",
-    "@ckeditor/ckeditor5-paragraph": "^19.0.0",
+    "@ckeditor/ckeditor5-dev-tests": "^20.0.0",
+    "@ckeditor/ckeditor5-editor-inline": "^20.0.0",
+    "@ckeditor/ckeditor5-essentials": "^20.0.0",
+    "@ckeditor/ckeditor5-paragraph": "^20.0.0",
     "eslint": "^5.5.0",
     "eslint-config-ckeditor5": "^2.0.0",
     "husky": "^1.3.1",


### PR DESCRIPTION
When trying to use the package with the version 20 of CKEditor the following error was raised:

Uncaught CKEditorError: ckeditor-duplicated-modules: Some CKEditor 5 modules are duplicated. Read more: https://ckeditor.com/docs/ckeditor5/latest/framework/guides/support/error-codes.html#error-ckeditor-duplicated-modules

This PR is for solving that.