### PR TITLE
ckeditor packages @ v25.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## [25.0.0](https://github.com/isaul32/ckeditor5-math/compare/v24.0.1...25.0.0) (2021-03-02)
+
+* Update dependencies.
+
 ## [24.0.1](https://github.com/isaul32/ckeditor5-math/compare/v24.0.0...24.0.1) (2021-02-28)
 
 * Fix balloon view position.

--- a/package.json
+++ b/package.json
@@ -11,19 +11,19 @@
     "ckeditor5-math"
   ],
   "dependencies": {
-    "@ckeditor/ckeditor5-clipboard": "^24.0.0",
-    "@ckeditor/ckeditor5-core": "^24.0.0",
-    "@ckeditor/ckeditor5-engine": "^24.0.0",
-    "@ckeditor/ckeditor5-ui": "^24.0.0",
-    "@ckeditor/ckeditor5-undo": "^24.0.0",
-    "@ckeditor/ckeditor5-utils": "^24.0.0",
-    "@ckeditor/ckeditor5-widget": "^24.0.0"
+    "@ckeditor/ckeditor5-clipboard": "^25.0.0",
+    "@ckeditor/ckeditor5-core": "^25.0.0",
+    "@ckeditor/ckeditor5-engine": "^25.0.0",
+    "@ckeditor/ckeditor5-ui": "^25.0.0",
+    "@ckeditor/ckeditor5-undo": "^25.0.0",
+    "@ckeditor/ckeditor5-utils": "^25.0.0",
+    "@ckeditor/ckeditor5-widget": "^25.0.0"
   },
   "devDependencies": {
-    "@ckeditor/ckeditor5-dev-tests": "^23.3.0",
-    "@ckeditor/ckeditor5-editor-inline": "^24.0.0",
-    "@ckeditor/ckeditor5-essentials": "^24.0.0",
-    "@ckeditor/ckeditor5-paragraph": "^24.0.0",
+    "@ckeditor/ckeditor5-dev-tests": "^24.3.0",
+    "@ckeditor/ckeditor5-editor-inline": "^25.0.0",
+    "@ckeditor/ckeditor5-essentials": "^25.0.0",
+    "@ckeditor/ckeditor5-paragraph": "^25.0.0",
     "eslint": "^7.1.0",
     "eslint-config-ckeditor5": "^3.0.0",
     "husky": "^4.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ckeditor5-math",
-  "version": "24.0.1",
+  "version": "25.0.0",
   "description": "Math feature for CKEditor 5.",
   "keywords": [
     "ckeditor",


### PR DESCRIPTION
Fixes #21

Updated via `ncu '/.*@ckeditor.*/' -u` ([more on ncu](https://www.npmjs.com/package/npm-check-updates))