### PR TITLE
Update packages for CKEditor 27.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## [27.0.0](https://github.com/isaul32/ckeditor5-math/compare/v26.0.0...v27.0.0) (2021-03-29)
+
+* Update dependencies.
+
 ## [26.0.0](https://github.com/isaul32/ckeditor5-math/compare/v25.0.0...v26.0.0) (2021-03-04)
 
 * Update dependencies.

--- a/package.json
+++ b/package.json
@@ -11,25 +11,25 @@
     "ckeditor5-math"
   ],
   "dependencies": {
-    "@ckeditor/ckeditor5-clipboard": "^26.0.0",
-    "@ckeditor/ckeditor5-core": "^26.0.0",
-    "@ckeditor/ckeditor5-engine": "^26.0.0",
-    "@ckeditor/ckeditor5-ui": "^26.0.0",
-    "@ckeditor/ckeditor5-undo": "^26.0.0",
-    "@ckeditor/ckeditor5-utils": "^26.0.0",
-    "@ckeditor/ckeditor5-widget": "^26.0.0"
+    "@ckeditor/ckeditor5-clipboard": "^27.0.0",
+    "@ckeditor/ckeditor5-core": "^27.0.0",
+    "@ckeditor/ckeditor5-engine": "^27.0.0",
+    "@ckeditor/ckeditor5-ui": "^27.0.0",
+    "@ckeditor/ckeditor5-undo": "^27.0.0",
+    "@ckeditor/ckeditor5-utils": "^27.0.0",
+    "@ckeditor/ckeditor5-widget": "^27.0.0"
   },
   "devDependencies": {
-    "@ckeditor/ckeditor5-dev-tests": "^24.3.0",
-    "@ckeditor/ckeditor5-editor-inline": "^26.0.0",
-    "@ckeditor/ckeditor5-essentials": "^26.0.0",
-    "@ckeditor/ckeditor5-paragraph": "^26.0.0",
+    "@ckeditor/ckeditor5-dev-tests": "^24.4.2",
+    "@ckeditor/ckeditor5-editor-inline": "^27.0.0",
+    "@ckeditor/ckeditor5-essentials": "^27.0.0",
+    "@ckeditor/ckeditor5-paragraph": "^27.0.0",
     "eslint": "^7.1.0",
-    "eslint-config-ckeditor5": "^3.0.0",
+    "eslint-config-ckeditor5": "^3.1.0",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.6",
     "stylelint": "^13.5.0",
-    "stylelint-config-ckeditor5": "^2.0.0"
+    "stylelint-config-ckeditor5": "^2.0.1"
   },
   "engines": {
     "node": ">=12.0.0",


### PR DESCRIPTION
See also: https://github.com/ckeditor/ckeditor5/releases/tag/v27.0.0