### PR TITLE
Upcast Quill style tags, fixes #39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 * #38: You can now boot into a development instance with `yarn start` (supports
   live reload)
+* #40 (fixed #39): Support for upcasting Quill style tags
 
 ## [27.1.1](https://github.com/isaul32/ckeditor5-math/compare/v27.1.0...v27.1.1) (2021-03-29)
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -50,6 +50,8 @@
 		<div id="editor">
     <p><script type="math/tex">e=mc^2</script></p>
     <p><script type="math/tex; mode=display">e=mc^2</script></p>
+	<!-- Quill Style Tag -->
+	<p><span class="ql-formula" data-value="e=mc^2"></span></p>
     </div>
 	</body>
 </html>

--- a/src/mathediting.js
+++ b/src/mathediting.js
@@ -108,6 +108,21 @@ export default class MathEditing extends Plugin {
 
 					return writer.createElement( params.display ? 'mathtex-display' : 'mathtex-inline', params );
 				}
+			} )
+			// KaTeX from Quill: https://github.com/quilljs/quill/blob/develop/formats/formula.js
+			.elementToElement( {
+				view: {
+					name: 'span',
+					classes: [ 'ql-formula' ]
+				},
+				model: ( viewElement, { writer } ) => {
+					const equation = viewElement.getAttribute( 'data-value' ).trim();
+					return writer.createElement( 'mathtex-inline', {
+						equation,
+						type: mathConfig.forceOutputType ? mathConfig.outputType : 'script',
+						display: false
+					} );
+				}
 			} );
 
 		// Model -> View (element)


### PR DESCRIPTION
See also: https://github.com/quilljs/quill/blob/develop/formats/formula.js

This will upcast `Formula` outputs from Quill (source: [formula.js](https://github.com/quilljs/quill/blob/develop/formats/formula.js))

`<span class="ql-formula" data-value="e=mc^2"></span>`

Will now be upcasted to `mathtex-inline`/`mathtex-display`

This doesn't affect any existing functionality