### PR TITLE
New option: `katexRenderOptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 ## Current
 
 -   Add latest changes here
+-   New configuration setting, `katexRenderOptions` (optional) - for KaTeX engines. Accepts object of `katex.render()` / `katex.renderToString()` [options](https://katex.org/docs/options.html):
+
+    ```js
+    InlineEditor.defaultConfig = {
+    	// ...
+    	math: {
+    		engine: 'katex'
+    		katexRenderOptions: {
+    			macros: {
+    				"\\neq": "\\mathrel{\\char`≠}",
+    			},
+    		},
+    	}
+    }
+    ```
+
+    via PR [#64](https://github.com/isaul32/ckeditor5-math/pull/64) by [Tony
+    Narlock](https://www.git-pull.com).
 
 ## [34.1.0](https://github.com/isaul32/ckeditor5-math/compare/v34.0.0...v34.1.0) (2022-06-21)
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ InlineEditor.defaultConfig = {
 		forceOutputType: false, // forces output to use outputType
 		enablePreview: true, // Enable preview view
 		previewClassName: [], // Class names to add to previews
-		popupClassName: [] // Class names to add to math popup balloon
+		popupClassName: [], // Class names to add to math popup balloon
+		katexRenderOptions: {}  // KaTeX only options for katex.render(ToString)
 	}
 }
 ```
@@ -134,6 +135,22 @@ InlineEditor.defaultConfig = {
 -   Tested with version **0.12.0**
 
 [<img src="https://katex.org/img/katex-logo-black.svg" width="130" alt="KaTeX">](https://katex.org/)
+
+-   `katexRenderOptions` - pass [options](https://katex.org/docs/options.html).
+
+	```js
+	InlineEditor.defaultConfig = {
+		// ...
+		math: {
+			engine: 'katex'
+			katexRenderOptions: {
+				macros: {
+					"\\neq": "\\mathrel{\\char`≠}",
+				},
+			},
+		}
+	}
+	```
 
 **Custom typesetting**
 

--- a/demo/app.js
+++ b/demo/app.js
@@ -3,18 +3,25 @@ import Essentials from "@ckeditor/ckeditor5-essentials/src/essentials";
 import Paragraph from "@ckeditor/ckeditor5-paragraph/src/paragraph";
 import Bold from "@ckeditor/ckeditor5-basic-styles/src/bold";
 import Italic from "@ckeditor/ckeditor5-basic-styles/src/italic";
-import CKEditorInspector from '@ckeditor/ckeditor5-inspector';
+import CKEditorInspector from "@ckeditor/ckeditor5-inspector";
 
 import Math from "../src/math";
 
 ClassicEditor.create(document.querySelector("#editor"), {
 	plugins: [Essentials, Paragraph, Bold, Italic, Math],
 	toolbar: ["bold", "italic", "math"],
-	math: { engine: "katex" },
+	math: {
+		engine: "katex",
+		katexRenderOptions: {
+			macros: {
+				"\\test": "\\mathrel{\\char`≠}",
+			},
+		},
+	},
 })
 	.then((editor) => {
 		console.log("Editor was initialized", editor);
-		CKEditorInspector.attach(editor)
+		CKEditorInspector.attach(editor);
 	})
 	.catch((error) => {
 		console.error(error);

--- a/demo/index.html
+++ b/demo/index.html
@@ -24,7 +24,7 @@
 			src="https://cdn.jsdelivr.net/npm/katex@0.13.5/dist/contrib/auto-render.min.js"
 			integrity="sha384-vZTG03m+2yp6N6BNi5iM4rW4oIwk5DfcNdFfxkk9ZWpDriOkXX8voJBFrAO7MpVl"
 			crossorigin="anonymous"
-			onload="renderMathInElement(document.body);"
+			onload="renderMathInElement(document.body, {'macros': {'\\test': '\\mathrel{\\char`≠}'}});"
 		></script>
 
 		<style>
@@ -50,6 +50,10 @@
 		<div id="editor">
     <p><script type="math/tex">e=mc^2</script></p>
     <p><script type="math/tex; mode=display">e=mc^2</script></p>
+	<p>
+	   This should show "\test" as ≠ via katexRenderOptions.macros:
+	   <script type="math/tex">\test</script>
+	</p>
 	<!-- Quill Style Tag -->
 	<p><span class="ql-formula" data-value="e=mc^2"></span></p>
     </div>

--- a/src/mathediting.js
+++ b/src/mathediting.js
@@ -32,7 +32,8 @@ export default class MathEditing extends Plugin {
 			forceOutputType: false,
 			enablePreview: true,
 			previewClassName: [],
-			popupClassName: []
+			popupClassName: [],
+			katexRenderOptions: {}
 		} );
 	}
 
@@ -168,7 +169,8 @@ export default class MathEditing extends Plugin {
 			const uiElement = writer.createUIElement( 'div', null, function( domDocument ) {
 				const domElement = this.toDomElement( domDocument );
 
-				renderEquation( equation, domElement, mathConfig.engine, mathConfig.lazyLoad, display, false );
+				renderEquation( equation, domElement, mathConfig.engine, mathConfig.lazyLoad, display, false, mathConfig.previewClassName,
+					null, mathConfig.katexRenderOptions );
 
 				return domElement;
 			} );

--- a/src/mathui.js
+++ b/src/mathui.js
@@ -78,7 +78,8 @@ export default class MathUI extends Plugin {
 			mathConfig.enablePreview,
 			this._previewUid,
 			mathConfig.previewClassName,
-			mathConfig.popupClassName
+			mathConfig.popupClassName,
+			mathConfig.katexRenderOptions
 		);
 
 		formView.mathInputView.bind( 'value' ).to( mathCommand, 'value' );

--- a/src/ui/mainformview.js
+++ b/src/ui/mainformview.js
@@ -23,7 +23,7 @@ import MathView from './mathview';
 import '../../theme/mathform.css';
 
 export default class MainFormView extends View {
-	constructor( locale, engine, lazyLoad, previewEnabled, previewUid, previewClassName, popupClassName ) {
+	constructor( locale, engine, lazyLoad, previewEnabled, previewUid, previewClassName, popupClassName, katexRenderOptions ) {
 		super( locale );
 
 		const t = locale.t;
@@ -53,7 +53,7 @@ export default class MainFormView extends View {
 			this.previewLabel.text = t( 'Equation preview' );
 
 			// Math element
-			this.mathView = new MathView( engine, lazyLoad, locale, previewUid, previewClassName );
+			this.mathView = new MathView( engine, lazyLoad, locale, previewUid, previewClassName, katexRenderOptions );
 			this.mathView.bind( 'display' ).to( this.displayButtonView, 'isOn' );
 
 			children = [

--- a/src/ui/mathview.js
+++ b/src/ui/mathview.js
@@ -3,13 +3,13 @@ import View from '@ckeditor/ckeditor5-ui/src/view';
 import { renderEquation } from '../utils';
 
 export default class MathView extends View {
-	constructor( engine, lazyLoad, locale, previewUid, previewClassName ) {
+	constructor( engine, lazyLoad, locale, previewUid, previewClassName, katexRenderOptions ) {
 		super( locale );
 
 		this.engine = engine;
 		this.lazyLoad = lazyLoad;
 		this.previewUid = previewUid;
-		this.previewClassName = previewClassName;
+		this.katexRenderOptions = katexRenderOptions;
 
 		this.set( 'value', '' );
 		this.set( 'display', false );
@@ -32,7 +32,8 @@ export default class MathView extends View {
 	}
 
 	updateMath() {
-		renderEquation( this.value, this.element, this.engine, this.lazyLoad, this.display, true, this.previewUid, this.previewClassName );
+		renderEquation( this.value, this.element, this.engine, this.lazyLoad, this.display, true, this.previewUid, this.previewClassName,
+			this.katexRenderOptions );
 	}
 
 	render() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,7 +44,8 @@ export function extractDelimiters( equation ) {
 }
 
 export async function renderEquation(
-	equation, element, engine = 'katex', lazyLoad, display = false, preview = false, previewUid, previewClassName = []
+	equation, element, engine = 'katex', lazyLoad, display = false, preview = false, previewUid, previewClassName = [],
+	katexRenderOptions = {}
 ) {
 	if ( engine === 'mathjax' && typeof MathJax !== 'undefined' ) {
 		if ( isMathJaxVersion3( MathJax.version ) ) {
@@ -77,7 +78,8 @@ export async function renderEquation(
 		selectRenderMode( element, preview, previewUid, previewClassName, el => {
 			katex.render( equation, el, {
 				throwOnError: false,
-				displayMode: display
+				displayMode: display,
+				...katexRenderOptions
 			} );
 			if ( preview ) {
 				moveAndScaleElement( element, el );
@@ -94,7 +96,7 @@ export async function renderEquation(
 				}
 				element.innerHTML = equation;
 				await global.window.CKEDITOR_MATH_LAZY_LOAD;
-				renderEquation( equation, element, engine, undefined, display, preview, previewUid, previewClassName );
+				renderEquation( equation, element, engine, undefined, display, preview, previewUid, previewClassName, katexRenderOptions );
 			}
 			catch ( err ) {
 				element.innerHTML = equation;


### PR DESCRIPTION
Fixes #63

## New option: `katexRenderOptions`, optional

_Pass-through to [options](https://katex.org/docs/options.html)_

```javascript
	math: {
		engine: "katex",
		katexRenderOptions: {
			macros: {
				"\\neq": "\\mathrel{\\char`≠}",
			},
		},
	},
````

## Preview

![image](https://user-images.githubusercontent.com/26336/182722506-87fbcdf0-d35a-4122-b888-5d87b6f7227a.png)
