### PR TITLE
Tag v37.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@isaul32/ckeditor5-math",
-  "version": "37.0.2",
+  "version": "37.1.0",
   "description": "Math feature for CKEditor 5.",
   "keywords": [
     "ckeditor",


### PR DESCRIPTION
Release includes CKEditor v37.1.0 pinnings.

See also: https://github.com/ckeditor/ckeditor5/releases/tag/v37.1.0