### PR TITLE
Fix lazyloading

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -129,7 +129,7 @@ export async function renderEquation(
 			);
 		}
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-	} else if ( engine === 'katex' ) {
+	} else if ( engine === 'katex' && window.katex !== undefined ) {
 		selectRenderMode(
 			element,
 			preview,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -89,7 +89,7 @@ export async function renderEquation(
 	previewClassName: Array<string> = [],
 	katexRenderOptions: KatexOptions = {}
 ): Promise<void> {
-	if ( engine == 'mathjax' ) {
+	if ( engine == 'mathjax' && window.MathJax !== undefined ) {
 		if ( isMathJaxVersion3( MathJax ) ) {
 			selectRenderMode(
 				element,

--- a/tests/lazyload.ts
+++ b/tests/lazyload.ts
@@ -1,0 +1,49 @@
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import MathUI from '../src/mathui';
+import type { EditorConfig } from '@ckeditor/ckeditor5-core/src/editor/editorconfig';
+import { expect } from 'chai';
+
+describe( 'Lazy load', () => {
+	let editorElement: HTMLDivElement;
+	let editor: ClassicEditor;
+	let lazyLoadInvoked: boolean;
+	let mathUIFeature: MathUI;
+
+	function buildEditor( config: EditorConfig ) {
+		return ClassicEditor
+			.create( editorElement, {
+				...config,
+				plugins: [ MathUI ]
+			} )
+			.then( newEditor => {
+				editor = newEditor;
+				mathUIFeature = editor.plugins.get( MathUI );
+			} );
+	}
+
+	beforeEach( () => {
+		editorElement = document.createElement( 'div' );
+		document.body.appendChild( editorElement );
+
+		lazyLoadInvoked = false;
+	} );
+
+	afterEach( () => {
+		editorElement.remove();
+		return editor.destroy();
+	} );
+
+	it( 'initializes lazy load for KaTeX', async () => {
+		await buildEditor( {
+			math: {
+				engine: 'katex',
+				lazyLoad: async () => {
+					lazyLoadInvoked = true;
+				}
+			}
+		} );
+
+		mathUIFeature._showUI();
+		expect( lazyLoadInvoked ).to.be.true;
+	} );
+} );


### PR DESCRIPTION
It appears that the conversion to TypeScript broke the lazyloading (first introduced in #5), we noticed it in production after upgrading to 41.4.2.

Identified an older version where it used to work: 9fa8967d95d58a66ab15fbdbbeae1b18e1e36635

![image](https://github.com/user-attachments/assets/572a8ccd-3cbd-4fa5-87f3-f993f9a13e94)

Since `engine` is set to `katex`, but `katex` is `undefined` it proceeds to render and it crashes:

![image](https://github.com/user-attachments/assets/09487bea-1400-4bf7-b2c3-704043a66ffe)

Since the old code checked for the presence of the `katex` instance, it would avoid this branch and continue to the lazy loading one.

Also took a time to write a test, but it is not perfect. It successfully caught the original issue and it passes now that the issue is fixed. I can't seem to be able to write a test for `lazyload` since it always seems that the second test fails (some kind of leak, maybe?).