### PR TITLE
Fix automath on clipboard paste

### DIFF
--- a/src/automath.ts
+++ b/src/automath.ts
@@ -29,7 +29,7 @@ export default class AutoMath extends Plugin {
 		const editor = this.editor;
 		const modelDocument = editor.model.document;
 
-		this.listenTo( editor.plugins.get( Clipboard ), 'inputTransformation', () => {
+		this.listenTo( editor.plugins.get( 'ClipboardPipeline' ), 'inputTransformation', () => {
 			const firstRange = modelDocument.selection.getFirstRange();
 			if ( !firstRange ) {
 				return;


### PR DESCRIPTION
It was broken since update to CKEditor v27.
See https://ckeditor.com/docs/ckeditor5/latest/updating/guides/update-to-27.html#clipboard-input-pipeline-integration